### PR TITLE
Implement startup default user bootstrap and update tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,6 +41,25 @@ The application follows a Model-View-Controller (MVC) like architecture:
 4.  The controller then uses components from `app/ui/` to construct an HTML response.
 5.  The response is sent back to the user's browser.
 
+## Default Accounts
+
+The application can automatically provision evaluator or applicant accounts on
+start-up.  Set the `DEFAULT_USERS` environment variable to a JSON array, for
+example:
+
+```json
+[
+  {"email": "evaluator@example.com", "password": "Secret123!", "role": "evaluator"},
+  {"email": "applicant@example.com", "password": "Secret456!"}
+]
+```
+
+Entries may also be supplied in a simple `email|password|role` format separated
+by commas, semicolons, or newlines for environments where JSON is awkward.  For
+legacy compatibility the `EVALUATOR_EMAILS` / `DEFAULT_EVALUATOR_PASSWORD`
+variables continue to work.  Password resets for existing accounts can be
+disabled by setting `DEFAULT_USERS_FORCE_RESET=false`.
+
 ## Domain-Specific Concepts
 
 *(This section is a placeholder for you to add more details about the business logic.)*

--- a/app/auth/bootstrap.py
+++ b/app/auth/bootstrap.py
@@ -1,0 +1,193 @@
+"""Utility helpers for bootstrapping default accounts.
+
+This module centralises the logic that creates or updates evaluator and
+applicant accounts that should always exist in the system.  It is designed to
+run during application start-up as well as from ad-hoc scripts such as
+``promote_user.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from fastlite import NotFoundError
+
+from auth.utils import get_password_hash
+
+
+@dataclass
+class DefaultUser:
+    """Represents a user that should exist in the database."""
+
+    email: str
+    password: Optional[str]
+    role: str = "applicant"
+    full_name: Optional[str] = None
+    birthday: Optional[str] = None
+
+
+def ensure_default_users(db) -> None:
+    """Ensure that pre-defined accounts exist in the database.
+
+    The function reads configuration from environment variables and then
+    creates or updates the accounts accordingly.  It is intentionally tolerant
+    so that providing no configuration simply results in a no-op.
+    """
+
+    users_to_ensure = _load_default_users_from_env()
+    if not users_to_ensure:
+        print("--- Default user bootstrap: nothing to do ---")
+        return
+
+    force_reset = _is_truthy(os.getenv("DEFAULT_USERS_FORCE_RESET", "true"))
+    default_birthday = os.getenv("DEFAULT_USERS_DEFAULT_BIRTHDAY", "1900-01-01")
+
+    users_table = db.t.users
+
+    for user in users_to_ensure:
+        email = user.email.strip().lower()
+        role = user.role or "applicant"
+        full_name = user.full_name or email.split("@")[0]
+        birthday = user.birthday or default_birthday
+
+        hashed_password = (
+            get_password_hash(user.password) if user.password else None
+        )
+
+        try:
+            existing = users_table[email]
+            updates = {}
+
+            if existing.get("role") != role:
+                updates["role"] = role
+
+            if hashed_password and (
+                force_reset or not existing.get("hashed_password")
+            ):
+                updates["hashed_password"] = hashed_password
+
+            if full_name and not existing.get("full_name"):
+                updates["full_name"] = full_name
+
+            if birthday and not existing.get("birthday"):
+                updates["birthday"] = birthday
+
+            if updates:
+                users_table.update(updates, pk_values=email)
+                print(
+                    f"--- Default user bootstrap: updated existing user '{email}' ({', '.join(updates.keys())}) ---"
+                )
+            else:
+                print(
+                    f"--- Default user bootstrap: user '{email}' already configured ---"
+                )
+
+        except NotFoundError:
+            if not hashed_password:
+                print(
+                    f"--- Default user bootstrap: skipping '{email}' because no password was provided ---"
+                )
+                continue
+
+            new_user = {
+                "email": email,
+                "hashed_password": hashed_password,
+                "full_name": full_name,
+                "birthday": birthday,
+                "role": role,
+            }
+            users_table.insert(new_user, pk="email")
+            print(
+                f"--- Default user bootstrap: created user '{email}' with role '{role}' ---"
+            )
+
+
+def _load_default_users_from_env() -> List[DefaultUser]:
+    """Load ``DefaultUser`` definitions from the environment.
+
+    The primary configuration surface is ``DEFAULT_USERS`` which accepts either
+    JSON or a simple ``email|password|role`` newline/comma separated format.
+    For backwards compatibility we also honour ``EVALUATOR_EMAILS`` and
+    ``DEFAULT_EVALUATOR_PASSWORD``.
+    """
+
+    configured_users: List[DefaultUser] = []
+
+    raw = os.getenv("DEFAULT_USERS")
+    if raw:
+        raw = raw.strip()
+        if raw:
+            parsed = _parse_default_users(raw)
+            configured_users.extend(parsed)
+
+    if configured_users:
+        return configured_users
+
+    legacy_emails = os.getenv("EVALUATOR_EMAILS")
+    if legacy_emails:
+        password = os.getenv("DEFAULT_EVALUATOR_PASSWORD", "Password123!")
+        for email in _split_entries(legacy_emails):
+            configured_users.append(
+                DefaultUser(email=email, password=password, role="evaluator")
+            )
+
+    return configured_users
+
+
+def _parse_default_users(raw: str) -> List[DefaultUser]:
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        return _parse_simple_default_users(raw)
+
+    if isinstance(loaded, dict):
+        loaded = [loaded]
+
+    users: List[DefaultUser] = []
+    for entry in loaded or []:
+        if not isinstance(entry, dict):
+            continue
+        email = entry.get("email")
+        password = entry.get("password")
+        role = entry.get("role", "applicant")
+        full_name = entry.get("full_name")
+        birthday = entry.get("birthday")
+        if email:
+            users.append(
+                DefaultUser(
+                    email=email,
+                    password=password,
+                    role=role,
+                    full_name=full_name,
+                    birthday=birthday,
+                )
+            )
+    return users
+
+
+def _parse_simple_default_users(raw: str) -> List[DefaultUser]:
+    users: List[DefaultUser] = []
+    for entry in _split_entries(raw):
+        delimiter = "|" if "|" in entry else ":"
+        parts = [part.strip() for part in entry.split(delimiter) if part.strip()]
+        if len(parts) < 2:
+            continue
+        email, password = parts[0], parts[1]
+        role = parts[2] if len(parts) > 2 else "applicant"
+        users.append(DefaultUser(email=email, password=password, role=role))
+    return users
+
+
+def _split_entries(raw: str) -> Iterable[str]:
+    for chunk in raw.replace(";", "\n").replace(",", "\n").splitlines():
+        chunk = chunk.strip()
+        if chunk:
+            yield chunk
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+

--- a/app/controllers/evaluator.py
+++ b/app/controllers/evaluator.py
@@ -380,7 +380,7 @@ class EvaluatorController:
         
         # --- PSEUDO-DATA SECTION ---
         pseudo_data = {
-            "education": "upper_secondary",
+            "education": "keskharidus",
             "has_prior_level_4": True,
             "base_training_hours": 40,
             "matching_experience_years": total_years

--- a/app/database.py
+++ b/app/database.py
@@ -2,12 +2,23 @@
 
 from fastlite import database
 import os
+from pathlib import Path
 import traceback # Added for potentially more robust error handling if needed later
 
 # --- Path Definition ---
 # Use an environment variable for the database file path.
 # Default to the old relative path for local development convenience.
-DB_FILE = os.environ.get("DATABASE_FILE_PATH", os.path.join(os.path.dirname(__file__), '..', 'data', 'applicant_data.db'))
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_DB_FILE_ENV = os.environ.get("DATABASE_FILE_PATH")
+
+if _DB_FILE_ENV:
+    db_path = Path(_DB_FILE_ENV)
+    if not db_path.is_absolute():
+        db_path = (_PROJECT_ROOT / db_path).resolve()
+else:
+    db_path = (_PROJECT_ROOT / 'data' / 'applicant_data.db').resolve()
+
+DB_FILE = str(db_path)
 # The directory is derived from the file path
 DATA_DIR = os.path.dirname(DB_FILE)
 

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from monsterui.all import *
 from controllers.employment_proof import EmploymentProofController
 from controllers.review import ReviewController
 from database import setup_database
+from auth.bootstrap import ensure_default_users
 from auth.middleware import AuthMiddleware
 from auth.utils import *
 from controllers.auth import AuthController
@@ -59,6 +60,8 @@ print(f"--- INFO [main.py]: Upload directory calculated as: {UPLOAD_DIR} ---")
 db = setup_database()
 if db is None:
     raise RuntimeError("Database setup failed, cannot start application.")
+
+ensure_default_users(db)
 
 # --- Controller Instantiation ---
 try:

--- a/app/promote_user.py
+++ b/app/promote_user.py
@@ -1,9 +1,15 @@
-# app/promote_user.py
+"""Maintained entry point for synchronising default users.
+
+The original deployment workflow executed this script to create evaluator
+accounts.  The logic now lives in :mod:`auth.bootstrap` so that it can be shared
+between the application start-up and this script.  Keeping the file means we do
+not have to update any external automation immediately.
+"""
+
 import sys
-import os
 from pathlib import Path
+
 from dotenv import load_dotenv
-import time
 
 # --- Setup Project Path ---
 APP_PATH = Path(__file__).parent
@@ -11,72 +17,18 @@ if str(APP_PATH) not in sys.path:
     sys.path.insert(0, str(APP_PATH))
 # --- End Setup ---
 
-# Load environment variables from .env file
 load_dotenv()
 
-from database import setup_database
-from auth.utils import get_password_hash
-from fastlite import NotFoundError
+from database import setup_database  # noqa: E402  pylint: disable=wrong-import-position
+from auth.bootstrap import ensure_default_users  # noqa: E402  pylint: disable=wrong-import-position
 
-def sync_evaluator_roles():
-    """
-    Reads evaluator emails from 'EVALUATOR_EMAILS' environment variable.
-    For each email, it ensures the user exists (creating them if necessary)
-    and that their role is 'evaluator' and their password is reset to the default.
-    """
-    print("--- Starting role sync. Waiting 5 seconds for volume to mount... ---")
-    time.sleep(5)
 
-    evaluator_emails_str = os.getenv("EVALUATOR_EMAILS")
-    if not evaluator_emails_str:
-        print("INFO: No EVALUATOR_EMAILS environment variable set. Nothing to sync.")
-        return
-
-    evaluator_emails = [email.strip() for email in evaluator_emails_str.split(',') if email.strip()]
-    if not evaluator_emails:
-        print("INFO: EVALUATOR_EMAILS variable is empty. Nothing to sync.")
-        return
-
-    print(f"--- Syncing roles for {len(evaluator_emails)} designated evaluators... ---")
-    
-    print("Connecting to the database...")
+def main() -> None:
+    print("--- Starting default user synchronisation ---")
     db = setup_database()
-    users_table = db.t.users
-    
-    default_password = os.getenv("DEFAULT_EVALUATOR_PASSWORD", "Password123!")
-    hashed_password = get_password_hash(default_password)
-
-    for email in evaluator_emails:
-        try:
-            user = users_table[email]
-            # --- THE FIX: Always update the password and role for existing users ---
-            update_data = {
-                "role": "evaluator",
-                "hashed_password": hashed_password
-            }
-            users_table.update(update_data, pk=email)
-            print(f"  - ✅ SYNCED: Ensured user '{email}' has 'evaluator' role and default password.")
-
-        except NotFoundError:
-            # User does NOT exist, so we create them
-            print(f"  - INFO: User '{email}' not found. Creating new evaluator account.")
-            try:
-                new_user = {
-                    "email": email,
-                    "hashed_password": hashed_password,
-                    "full_name": email.split('@')[0],
-                    "birthday": "1900-01-01",
-                    "role": "evaluator"
-                }
-                users_table.insert(new_user, pk='email')
-                print(f"  - ✅ CREATED: New evaluator user '{email}' was created with a default password.")
-            except Exception as e:
-                print(f"  - ❌ ERROR: Failed to create new user '{email}': {e}")
-        except Exception as e:
-            print(f"  - ❌ ERROR: An unexpected error occurred for user '{email}': {e}")
-
-    print("--- Role sync complete. ---")
+    ensure_default_users(db)
+    print("--- Default user synchronisation complete ---")
 
 
 if __name__ == "__main__":
-    sync_evaluator_roles()
+    main()

--- a/tests/auth/test_bootstrap.py
+++ b/tests/auth/test_bootstrap.py
@@ -1,0 +1,88 @@
+import importlib
+import json
+
+import pytest
+
+from auth.utils import verify_password, get_password_hash
+
+
+@pytest.fixture
+def isolated_db(monkeypatch, tmp_path):
+    for key in [
+        "DEFAULT_USERS",
+        "DEFAULT_USERS_FORCE_RESET",
+        "DEFAULT_USERS_DEFAULT_BIRTHDAY",
+        "EVALUATOR_EMAILS",
+        "DEFAULT_EVALUATOR_PASSWORD",
+        "DATABASE_FILE_PATH",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    db_path = tmp_path / "test_app.db"
+    monkeypatch.setenv("DATABASE_FILE_PATH", str(db_path))
+
+    import app.database as database_module
+
+    importlib.reload(database_module)
+    db = database_module.setup_database()
+    try:
+        yield db
+    finally:
+        monkeypatch.delenv("DATABASE_FILE_PATH", raising=False)
+        importlib.reload(database_module)
+
+
+def test_default_users_created(monkeypatch, isolated_db):
+    db = isolated_db
+
+    config = [
+        {"email": "evaluator@example.com", "password": "Secret123!", "role": "evaluator"},
+        {"email": "applicant@example.com", "password": "Secret456!"},
+    ]
+    monkeypatch.setenv("DEFAULT_USERS", json.dumps(config))
+
+    from auth.bootstrap import ensure_default_users
+
+    ensure_default_users(db)
+
+    users = db.t.users
+    evaluator = users["evaluator@example.com"]
+    applicant = users["applicant@example.com"]
+
+    assert evaluator["role"] == "evaluator"
+    assert verify_password("Secret123!", evaluator["hashed_password"])
+    assert applicant["role"] == "applicant"
+    assert verify_password("Secret456!", applicant["hashed_password"])
+
+def test_default_users_do_not_override_password_when_disabled(monkeypatch, isolated_db):
+    db = isolated_db
+
+    existing_password = get_password_hash("OldSecret!1")
+    db.t.users.insert(
+        {
+            "email": "existing@example.com",
+            "hashed_password": existing_password,
+            "full_name": "Existing",
+            "birthday": "1990-01-01",
+            "role": "applicant",
+        },
+        pk="email",
+    )
+
+    monkeypatch.setenv("DEFAULT_USERS_FORCE_RESET", "false")
+    monkeypatch.setenv(
+        "DEFAULT_USERS",
+        json.dumps([
+            {"email": "existing@example.com", "password": "NewPassword!2", "role": "evaluator"}
+        ]),
+    )
+
+    from auth.bootstrap import ensure_default_users
+
+    ensure_default_users(db)
+
+    user = db.t.users["existing@example.com"]
+    # Role should be updated but password must remain the same
+    assert user["role"] == "evaluator"
+    assert verify_password("OldSecret!1", user["hashed_password"])
+    assert not verify_password("NewPassword!2", user["hashed_password"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def authenticated_client(client):
     }
     # Perform the login. The TestClient will automatically manage the session cookie.
     client.post("/login", data=login_data)
+    client.get("/dashboard")
 
     # --- NEW: Select some qualifications for the test user ---
     # This data needs to match the expected format for /app/kutsed/submit

--- a/tests/test_2applicants.py
+++ b/tests/test_2applicants.py
@@ -19,14 +19,19 @@ def successful_applicant_client(client: TestClient):
     This fixture yields the authenticated client and then cleans up the user's data.
     """
     email = "successful.applicant@example.com"
-    
+
     # --- Setup ---
+    users_table.delete_where("email = ?", [email])
+    qualifications_table.delete_where("user_email = ?", [email])
+    experience_table.delete_where("user_email = ?", [email])
+    documents_table.delete_where("user_email = ?", [email])
     client.post("/register", data={
         "email": email, "password": "password123", "confirm_password": "password123",
         "full_name": "Success Applicant", "birthday": "1990-05-15"
     })
     client.post("/login", data={"email": email, "password": "password123"})
-    
+    client.get("/dashboard")
+
     # Add qualifications to make work experience tab available
     client.post("/app/kutsed/submit", data={"qual_1_0": "on"})
 
@@ -46,13 +51,17 @@ def overlapping_applicant_client(client: TestClient):
     Creates, authenticates, and sets up an applicant with overlapping experience.
     """
     email = "overlapping.applicant@example.com"
-    
+
     # --- Setup ---
+    users_table.delete_where("email = ?", [email])
+    qualifications_table.delete_where("user_email = ?", [email])
+    experience_table.delete_where("user_email = ?", [email])
     client.post("/register", data={
         "email": email, "password": "password123", "confirm_password": "password123",
         "full_name": "Overlapping Applicant", "birthday": "1985-10-20"
     })
     client.post("/login", data={"email": email, "password": "password123"})
+    client.get("/dashboard")
     client.post("/app/kutsed/submit", data={"qual_1_0": "on"})
 
 


### PR DESCRIPTION
## Summary
- add an auth bootstrap helper to create or sync default evaluator/applicant accounts from environment configuration and reuse it in the promote_user script
- resolve relative database paths consistently and run the bootstrap during FastHTML startup while aligning evaluator pseudo-data with qualification rules
- document default account configuration and harden test fixtures for dashboard access and cleanup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd701d90e08331aac838bedcf1f9d1