### PR TITLE
Handle comma separated default user JSON entries

### DIFF
--- a/app/auth/bootstrap.py
+++ b/app/auth/bootstrap.py
@@ -153,6 +153,10 @@ def _parse_default_users(raw: str) -> List[DefaultUser]:
             if index >= raw_length:
                 break
 
+            if raw[index] == ",":
+                index += 1
+                continue
+
             if raw[index] != "{":
                 parsed_objects = []
                 break

--- a/tests/auth/test_bootstrap.py
+++ b/tests/auth/test_bootstrap.py
@@ -112,3 +112,29 @@ def test_newline_separated_json_users(monkeypatch, isolated_db):
     assert second["role"] == "applicant"
     assert verify_password("FirstPass!1", first["hashed_password"])
     assert verify_password("SecondPass!2", second["hashed_password"])
+
+
+def test_comma_separated_json_users(monkeypatch, isolated_db):
+    db = isolated_db
+
+    raw = ",".join(
+        [
+            '{"email": "comma1@example.com", "password": "CommaPass!1", "role": "evaluator"}',
+            '{"email": "comma2@example.com", "password": "CommaPass!2", "role": "applicant"}',
+        ]
+    )
+
+    monkeypatch.setenv("DEFAULT_USERS", raw)
+
+    from auth.bootstrap import ensure_default_users
+
+    ensure_default_users(db)
+
+    users = db.t.users
+    first = users["comma1@example.com"]
+    second = users["comma2@example.com"]
+
+    assert first["role"] == "evaluator"
+    assert second["role"] == "applicant"
+    assert verify_password("CommaPass!1", first["hashed_password"])
+    assert verify_password("CommaPass!2", second["hashed_password"])


### PR DESCRIPTION
## Summary
- allow `_parse_default_users` to treat commas as delimiters when parsing JSON objects so valid entries avoid the fallback path
- add coverage to ensure comma-separated default user definitions provision each account correctly

## Testing
- pytest tests/auth/test_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7e2110a883318140931e2bd1b8ea