### PR TITLE
Wrap serve call with main guard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -441,4 +441,5 @@ def view_secure_file(request: Request, doc_id: int):
         return Response("Could not generate secure link for the file.", status_code=500)
 
 # Start server
-serve()
+if __name__ == "__main__":
+    serve()


### PR DESCRIPTION
## Summary
- wrap the module-level serve invocation in a __main__ guard so the app only boots when executed directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0223454fc8331b24fa8fbf10169fe